### PR TITLE
fix: fixed std::string untimely destroy

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -25,8 +25,8 @@ Napi::Value HashIt(const Napi::CallbackInfo& args) {
   }
 
   Napi::String path = args[0].As<Napi::String>();
-
-  char* jar_file_path = (char*)path.Utf8Value().c_str();
+  std::string path_u8 = path.Utf8Value();
+  char* jar_file_path = (char*)path_u8.c_str();
 
   Buffer jar_buffer = get_jar_contents(jar_file_path);
     if (jar_buffer.empty()) {


### PR DESCRIPTION
`path.Utf8Value()` return `const string` which will destroy after define `jar_file_path`,therefore the `jar_file_path` is [Dangling pointer](https://en.wikipedia.org/wiki/Dangling_pointer).
You can check this bug with a long jar file name,in my machine it is 15 bytes like `abcdefghijk.jar`.That will throw `TypeError: Jar file was empty` .
Just create a `std::string` variable and get it's content pointer can fix this bug.