### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ self-hosted, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     needs: [ verify ]
     if: needs.verify.outputs.new-release-published == 'true'
@@ -56,7 +56,7 @@ jobs:
     needs: [ verify, build ]
     if: needs.verify.outputs.new-release-published == 'true'
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3
       - name: Set up node
@@ -72,7 +72,7 @@ jobs:
           path: prebuilds
       - uses: actions/download-artifact@master
         with:
-          name: prebuilds-ubuntu-latest
+          name: prebuilds-self-hosted
           path: prebuilds
       - uses: actions/download-artifact@master
         with:


### PR DESCRIPTION
Replace compatible GitHub-hosted runner selections with the self-hosted runner.